### PR TITLE
fix: broken memEth link

### DIFF
--- a/pages/contracts.mdx
+++ b/pages/contracts.mdx
@@ -4,6 +4,6 @@ Checkout the core Memswap Contracts:
 
 - [ERC20 Memswap Contract](/contracts/erc-20)
 - [ERC721 Memswap Contract](/contracts/erc-721)
-- [memEth Contract](/contracts/memeth)
+- [memEth Contract](/contracts/memEth)
 
 or the full contract GitHub repo [here](https://github.com/memswap-protocol/memswap/tree/main/contracts)


### PR DESCRIPTION
:v: just reading thru the docs and found this on [the contracts page](https://docs.memswap.xyz/contracts)

https://docs.memswap.xyz/contracts/memeth

vs

https://docs.memswap.xyz/contracts/memEth